### PR TITLE
Added system name on the game list where metadata is visible

### DIFF
--- a/aspect-ratio-16-10.xml
+++ b/aspect-ratio-16-10.xml
@@ -215,9 +215,14 @@ based on 1920x1080
          <video name="game-art">
             <pos>0.588541666666667 0.310185185185185</pos><!-- 1130 335 -->
          </video>
-         <text name="game-description">
+         <text name="game-system-name">
             <pos>0.427083333333333 0.583333333333333</pos><!-- 820 630 -->
-            <size>0.322916666666667 0.231481481481481</size><!-- 620 250 -->
+            <size>0.322916666666667 0.0277777777777778</size><!-- 620 30 -->
+            <fontSize>${gamelistDescriptionFontSize}</fontSize>
+         </text>
+         <text name="game-description">
+            <pos>0.427083333333333 0.6296296296296296</pos><!-- 820 680 -->
+            <size>0.322916666666667 0.2037037037037037</size><!-- 620 220 -->
             <fontSize>${gamelistDescriptionFontSize}</fontSize>
             <lineSpacing>${gamelistDescriptionLineSpacing}</lineSpacing>
          </text>

--- a/aspect-ratio-16-9.xml
+++ b/aspect-ratio-16-9.xml
@@ -215,9 +215,14 @@ based on 1920x1080
          <video name="game-art">
             <pos>0.588541666666667 0.310185185185185</pos><!-- 1130 335 -->
          </video>
-         <text name="game-description">
+         <text name="game-system-name">
             <pos>0.427083333333333 0.583333333333333</pos><!-- 820 630 -->
-            <size>0.322916666666667 0.231481481481481</size><!-- 620 250 -->
+            <size>0.322916666666667 0.0277777777777778</size><!-- 620 30 -->
+            <fontSize>${gamelistDescriptionFontSize}</fontSize>
+         </text>
+         <text name="game-description">
+            <pos>0.427083333333333 0.6296296296296296</pos><!-- 820 680 -->
+            <size>0.322916666666667 0.2037037037037037</size><!-- 620 220 -->
             <fontSize>${gamelistDescriptionFontSize}</fontSize>
             <lineSpacing>${gamelistDescriptionLineSpacing}</lineSpacing>
          </text>

--- a/aspect-ratio-4-3.xml
+++ b/aspect-ratio-4-3.xml
@@ -231,9 +231,14 @@ based on 1440x1080
             <size>0.422222222222222 0.055555555555556</size><!-- 608 60 -->
             <visible>true</visible>
          </rating>
+         <text name="game-system-name">
+            <pos>0.5305555555555556 0.6018518518518519</pos><!-- 764 656 -->
+            <size>0,4222222222222222 0.0277777777777778</size><!-- 608 30 -->
+            <fontSize>${gamelistDescriptionFontSize}</fontSize>
+         </text>
          <text name="game-description">
-            <pos>0.529166666666667 0.62962962962963</pos><!-- 762 680 -->
-            <size>0.422222222222222 0.225925925925926</size><!-- 608 244 -->
+            <pos>0.529166666666667 0.6666666666666667</pos><!-- 762 720 -->
+            <size>0.422222222222222 0.1981481481481481</size><!-- 608 214 -->
             <fontSize>${gamelistDescriptionFontSize}</fontSize>
             <lineSpacing>${gamelistDescriptionLineSpacing}</lineSpacing>
             <visible>true</visible>

--- a/theme.xml
+++ b/theme.xml
@@ -314,7 +314,7 @@ license:       creative commons CC-BY-NC-SA
             <fontPath>${fontBold}</fontPath>
             <color>${gameDescription}</color>
             <metadata>sourceSystemFullname</metadata>
-            <letterCase>capitalize</letterCase>
+            <letterCase>uppercase</letterCase>
          </text>
          <text name="game-description">
             <fontPath>${fontRegular}</fontPath>

--- a/theme.xml
+++ b/theme.xml
@@ -310,6 +310,12 @@ license:       creative commons CC-BY-NC-SA
             <iterationCount>1</iterationCount>
             <onIterationsDone>image</onIterationsDone>
          </video>
+         <text name="game-system-name">
+            <fontPath>${fontBold}</fontPath>
+            <color>${gameDescription}</color>
+            <metadata>sourceSystemFullname</metadata>
+            <letterCase>capitalize</letterCase>
+         </text>
          <text name="game-description">
             <fontPath>${fontRegular}</fontPath>
             <color>${gameDescription}</color>


### PR DESCRIPTION
Added a label on the game list underneath the game art to display the system name so that while searching the collections users can identify which system a game belongs to.